### PR TITLE
extend NAME to get whatis entry in manpage

### DIFF
--- a/lib/Sub/WrapPackages/CallTree.pm
+++ b/lib/Sub/WrapPackages/CallTree.pm
@@ -27,7 +27,7 @@ sub import {
 
 =head1 NAME
 
-Sub::WrapPackages::CallTree
+Sub::WrapPackages::CallTree - show a tree of function calls
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Sub-WrapPackages.
We thought you might be interested in it too.

    Description: extend NAME to get whatis entry in manpage
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2022-07-23
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libsub-wrappackages-perl/raw/master/debian/patches/pod.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
